### PR TITLE
fix: overlapping elements

### DIFF
--- a/src/widgets/skills.ts
+++ b/src/widgets/skills.ts
@@ -71,28 +71,28 @@ export default function skillsWidget(
     const toolsList: string[] = toolsString.split(',')
     const softwareList: string[] = softwareString.split(',')
 
-    const rowHeightLanguages = Math.round((languageList.length - 0.1) / 7) > 1 ? Math.round((languageList.length - 0.1) / 7) : 1
+    const rowHeightLanguages = Math.ceil(languageList.length / 7)
     const languagesTitleHeight = FIRST_ROW 
 
-    const rowHeightFrameworks = Math.round((frameworkList.length - 0.1) / 7) > 1 ? Math.round((frameworkList.length - 0.1) / 7) : 1
+    const rowHeightFrameworks = Math.ceil(frameworkList.length / 7)
     const frameworkTitleHeight = languagesTitleHeight 
     + ((languageList.length > 1 || languageList[0] !== 'undefined' ? 1  : 0) * PAD) 
     + ((languageList.length > 1 || languageList[0] !== 'undefined' ? rowHeightLanguages : 0) * ROW) 
     + (includeNames && (languageList.length > 1 || languageList[0] !== 'undefined') ? (rowHeightFrameworks) * 25 : 0)
     
-    const rowHeightLibraries = Math.round((libraryList.length - 0.1) / 7) > 1 ? Math.round((libraryList.length - 0.1) / 7) : 1
+    const rowHeightLibraries = Math.ceil(libraryList.length / 7)
     const libraryTitleHeight = frameworkTitleHeight 
     + ((frameworkList.length > 1 || frameworkList[0] !== 'undefined' ? 1  : 0) * PAD) 
     + ((frameworkList.length > 1 || frameworkList[0] !== 'undefined' ? rowHeightFrameworks : 0) * ROW)
     +  (includeNames && (frameworkList.length > 1 || frameworkList[0] !== 'undefined') ? (rowHeightLibraries) * 25 : 0)
 
-    const rowHeightTools = Math.round((toolsList.length - 0.1) / 7) > 1 ? Math.round((toolsList.length - 0.1) / 7) : 1
+    const rowHeightTools = Math.ceil(toolsList.length / 7)
     const toolsTitleHeight = libraryTitleHeight
     + ((libraryList.length > 1 || libraryList[0] !== 'undefined' ? 1  : 0) * PAD) 
     + ((libraryList.length > 1 || libraryList[0] !== 'undefined' ? rowHeightLibraries : 0) * ROW)
     +  (includeNames  && (libraryList.length > 1 || libraryList[0] !== 'undefined') ? (rowHeightTools) * 25 : 0)
 
-    const rowHeightSoftware = Math.round((softwareList.length - 0.1) / 7) > 1 ? Math.round((softwareList.length - 0.1) / 7) : 1
+    const rowHeightSoftware = Math.ceil(softwareList.length / 7)
     const softwareTitleHeight = toolsTitleHeight
     + ((toolsList.length > 1 || toolsList[0] !== 'undefined' ? 1  : 0) * PAD) 
     + ((toolsList.length > 1 || toolsList[0] !== 'undefined' ? rowHeightTools : 0) * ROW)


### PR DESCRIPTION
# FIX: Overlapping elements

Sorry for my poor English.  

## Bug Description

If there are more than 2 rows and the last row has  
less than 4 elements, it overlaps the section below.  
[![GitHub WidgetBox](http://github-widgetbox.vercel.app/api/skills?tools=git,docker,npm,yarn,webpack,gulp,firebase,shopify,woocommerce,vercel&languages=js,ts,html,css,c,cpp,csharp,swift,go,python,java,rust,kotlin,ruby,erlang&software=linux,windows)](https://github.com/Jurredr/github-widgetbox)  
Fixed by setting row height to `Math.ceil(list.length / 7)`  
instead of `Math.round((list.length - 0.1) / 7) > 1 ? Math.round((list.length - 0.1) / 7) : 1`  

Fixes: #20